### PR TITLE
Add Support for saving the current weekday in URL

### DIFF
--- a/src/components/today-overview/TodayOverview.tsx
+++ b/src/components/today-overview/TodayOverview.tsx
@@ -29,6 +29,7 @@ const TodayOverview = () => {
         .add(navData ? navData.selectedWeekday : 0, 'day')
         .format('YYYY-MM-DD'),
     },
+    skip: navData && navData.selectedWeekday < 0,
   });
 
   const content =


### PR DESCRIPTION
If there is a weekday parameter it will take priority over the previous logic (choosing today, or next monday if today lies on the weekend). 

This PR will close #47 and #46