### PR TITLE
Support english dish names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ yarn-error.log*
 **/public/sw.js.map
 **/public/workbox-*.js.map
 **/public/worker-*.js.map
+
+# jetbrains IDEs
+.idea/

--- a/src/components/today-overview/TodayOverview.tsx
+++ b/src/components/today-overview/TodayOverview.tsx
@@ -44,7 +44,7 @@ const TodayOverview = () => {
     data.occurrencesByDate.map(({ dish: { nameDe, nameEn }, id }) => {
       // Fallback to german value if no english value is present
       return (
-        <Dish name={locale == 'en' ? nameEn ?? nameDe : nameDe} key={id} />
+        <Dish name={locale === 'en' ? nameEn ?? nameDe : nameDe} key={id} />
       );
     });
 

--- a/src/components/today-overview/TodayOverview.tsx
+++ b/src/components/today-overview/TodayOverview.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'next-i18next';
-import React from 'react';
+import { useRouter } from 'next/router';
+import React, { useMemo } from 'react';
 import {
   GetOccurrencesByDateQuery,
   GetOccurrencesByDateQueryVariables,
@@ -18,6 +19,12 @@ import Dish from '../dish/';
 import styles from './TodayOverview.module.scss';
 
 const TodayOverview = () => {
+  const { locale: routerLocale } = useRouter();
+  const locale = useMemo(
+    () => (routerLocale ? routerLocale : 'de'),
+    [routerLocale],
+  );
+
   const { t } = useTranslation('common');
   const { data: navData } = useQuery<Navigation>(GET_NAVIGATION);
   const { loading, data, error } = useQuery<
@@ -34,8 +41,11 @@ const TodayOverview = () => {
 
   const content =
     data &&
-    data.occurrencesByDate.map((elem) => {
-      return <Dish name={elem.dish.nameDe} key={elem.id} />;
+    data.occurrencesByDate.map(({ dish: { nameDe, nameEn }, id }) => {
+      // Fallback to german value if no english value is present
+      return (
+        <Dish name={locale == 'en' ? nameEn ?? nameDe : nameDe} key={id} />
+      );
     });
 
   const contentWithMessage =

--- a/src/graphql/graphql-types.ts
+++ b/src/graphql/graphql-types.ts
@@ -408,7 +408,12 @@ export type GetOccurrencesByDateQuery = {
     priceStudent?: number | null;
     priceStaff?: number | null;
     priceGuest?: number | null;
-    dish: { __typename?: 'Dish'; id: string; nameDe: string };
+    dish: {
+      __typename?: 'Dish';
+      id: string;
+      nameDe: string;
+      nameEn?: string | null;
+    };
     sideDishes: Array<{ __typename?: 'Dish'; id: string; nameDe: string }>;
     tags: Array<{
       __typename?: 'Tag';

--- a/src/graphql/queries/getOccurrenceByDate.gql.ts
+++ b/src/graphql/queries/getOccurrenceByDate.gql.ts
@@ -7,6 +7,7 @@ export const GET_OCCURRENCES_BY_DATE = gql`
       dish {
         id
         nameDe
+        nameEn
       }
       sideDishes {
         id


### PR DESCRIPTION
As english translations for dishes are not guaranteed, there is a fallback to the german version of the dish's name in place.
The alt-text of the dish's image is also set to the correct version.

**Further consideration is needed on how to visualize the missing native (english) language value.**
Currently this is done intransparently to the user, which may cause confusion, however I could not think of an easy way to share this information with the user.