### PR TITLE
fix: Hide occurrences containing the same dish id for a given day

### DIFF
--- a/src/components/today-overview/TodayOverview.tsx
+++ b/src/components/today-overview/TodayOverview.tsx
@@ -33,9 +33,15 @@ const TodayOverview = () => {
     skip: !navData || navData.selectedDate.length < DATE_FORMAT.length,
   });
 
+  const uniqueDishes = data && [
+    ...new Map(
+      data.occurrences.map((item) => [item['dish'].id, item]),
+    ).values(),
+  ];
+
   const content =
     data &&
-    data.occurrences.map((occurrence) => (
+    uniqueDishes.map((occurrence) => (
       <Occurrence occurrence={occurrence} key={occurrence.id} />
     ));
 


### PR DESCRIPTION
The bug resulting in multiple occurrences for a single day was already fixed on the scraper side. It would be best to retroactively clean up the database and remove duplicate entries, but as this is a risky process we should avoid it for now.

After we prune the entires, this workaround can be removed.