### PR TITLE
fix: Disable show more tags button

### DIFF
--- a/src/components/occurrence/tags/OccurrenceTags.module.scss
+++ b/src/components/occurrence/tags/OccurrenceTags.module.scss
@@ -18,7 +18,7 @@
 }
 
 .showMore {
-  cursor: pointer;
+  cursor: not-allowed;
 }
 
 .tagTooltip {


### PR DESCRIPTION
Only a cursor change was necessary to streamline the styling.

Closes #165.